### PR TITLE
readme: suggest upstream docker/setup-buildx-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ jobs:
       - uses: runs-on/snapshot@v1
         with:
           path: /var/lib/docker
-      # setup-buildx-action from a PR that will be merged soon?
-      - uses: aptos-labs/setup-buildx-action@balaji/retain-cache
+      - uses: docker/setup-buildx-action@v3
         with:
           name: runs-on
           keep-state: true


### PR DESCRIPTION
`docker/setup-buildx-action@v3` added support for `keep-state`: https://github.com/docker/setup-buildx-action/releases/tag/v3.11.0

From our testing, it seems to work as expected.