### PR TITLE
fix: Argument list on windows cannot be an empty string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,10 @@ function main() {
     const binary = chooseBinary()
     const mainScript = `${__dirname}/${binary}`
     if (os.platform() === WINDOWS) {
+        const args = ARGS.length > 0 ? `-ArgumentList "${ARGS.join(' ')}"` : ''
         childProcess.execFileSync('powershell', [
             '-Command',
-            `Start-Process -FilePath "${mainScript}" -ArgumentList "${ARGS.join(' ')}" -Verb RunAs -WindowStyle Hidden -Wait`
+            `Start-Process -FilePath "${mainScript}" ${args} -Verb RunAs -WindowStyle Hidden -Wait`
         ], { stdio: 'inherit' })
     } else {
         childProcess.execFileSync('sudo', ['-n', '-E', mainScript, ...ARGS], { stdio: 'inherit' })


### PR DESCRIPTION
When trying to create a Snapshot on Windows, an error is thrown because the -ArgumentList option cannot be an empty string. This change tries to address that issue.

```powershell
Start-Process : Cannot validate argument on parameter 'ArgumentList'. The argument is null or empty. Provide an 
argument that is not null or empty, and then try the command again.
At line:1 char:113
+ ... ions\runs-on\snapshot\v1/main-windows-amd64" -ArgumentList "" -Verb R ...
+                                                                ~~
    + CategoryInfo          : InvalidData: (:) [Start-Process], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartProcessCommand
 
node:child_process:930
    throw err;
    ^
Error: Command failed: powershell -Command Start-Process -FilePath "C:\actions-runner\_work\_actions\runs-on\snapshot\v1/main-windows-amd64" -ArgumentList "" -Verb RunAs -WindowStyle Hidden -Wait
    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at checkExecSyncError (node:child_process:891:11)
    at Object.execFileSync (node:child_process:927:15)
    at main (C:\actions-runner\_work\_actions\runs-on\snapshot\v1\index.js:33:22)
    at Object.<anonymous> (C:\actions-runner\_work\_actions\runs-on\snapshot\v1\index.js:44:5)
    at Module._compile (node:internal/modules/cjs/loader:1529:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1613:10)
    at Module.load (node:internal/modules/cjs/loader:1275:32)
    at Module._load (node:internal/modules/cjs/loader:1096:12) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 2944,
  stdout: null,
  stderr: null
}
Node.js v20.19.3
```

